### PR TITLE
fallback is not used when $filePath is null

### DIFF
--- a/source/app/code/community/Yireo/EmailOverride/Model/Translate.php
+++ b/source/app/code/community/Yireo/EmailOverride/Model/Translate.php
@@ -54,7 +54,7 @@ class Yireo_EmailOverride_Model_Translate extends Mage_Core_Model_Translate
         }
 
         $filePath = $this->getLocaleOverrideFile($localeCode, 'template'.DS.$type.DS.$file);
-        if (!empty($filePath) && !file_exists($filePath)) {
+        if (empty($filePath) || !file_exists($filePath)) {
             return parent::getTemplateFile($file, $type, $localeCode);
         }
 


### PR DESCRIPTION
$filePath can be null if no override file is found in $this->getLocaleOverrideFile(). in this case, the parent's getTemplateFile are never be called due to the wrong boolean checks. the parent should be called if either of the two statements are true:
- $filePath is empty
- the file does not exist

this bite me after switching to a thirdparty newsletter extension which had email template files for which i did not yet have template override files created.