### PR TITLE
Modman fix for magerun/composer installer

### DIFF
--- a/modman
+++ b/modman
@@ -1,3 +1,3 @@
 # Modman file
 source/app/code/community/Yireo/EmailOverride app/code/community/Yireo/EmailOverride
-source/app/etc/modules/Yireo_EmailOverride.xml app/etc/modules/
+source/app/etc/modules/Yireo_EmailOverride.xml app/etc/modules/Yireo_EmailOverride.xml


### PR DESCRIPTION
The PHP modman port that is used in magento composer installer / magerun
has problems (maybe even pure modman itself) to deal with modules XML
target directory on cleanup.