### PR TITLE
Implement support for sub themes

### DIFF
--- a/source/app/code/community/Yireo/EmailOverride/Helper/Data.php
+++ b/source/app/code/community/Yireo/EmailOverride/Helper/Data.php
@@ -96,6 +96,10 @@ class Yireo_EmailOverride_Helper_Data extends Mage_Core_Helper_Abstract
         if(empty($packageName) || in_array($theme, array('base', 'default'))) {
             $packageName = Mage::getStoreConfig('design/package/name', $store);
         }
+        
+        if(empty($theme)) {
+            $theme = Mage::getStoreConfig('design/theme/default', $store);
+        }
 
         if(empty($theme) || in_array($theme, array('default'))) {
             $theme = Mage::getStoreConfig('design/theme/locale', $store);


### PR DESCRIPTION
Magento supports a mechanism of sub themes. This means you can have a customizes theme next to the default one. 
```app/design/frontend/ultimo/default```. This is where the extension currently looks for email template. However, I am using ULTMO theme which strongly recommend the usage of sub theme to be safe on updates of the theme. The path looks then like ```app/design/frontend/ultimo/customtheme```. 

This change looks first if the user defined a default theme (like customtheme). Otherwise it will take the one from /ultimo/default.