### PR TITLE
Fallback to en_US before using default fallback

### DIFF
--- a/source/app/code/community/Yireo/EmailOverride/Helper/Data.php
+++ b/source/app/code/community/Yireo/EmailOverride/Helper/Data.php
@@ -23,10 +23,17 @@ class Yireo_EmailOverride_Helper_Data extends Mage_Core_Helper_Abstract
     public function getLocaleOverrideFile($localeCode, $fileName, $store = null)
     {
         $paths = $this->getLocalePaths($store);
-        foreach($paths as $path) {
-            $filePath = $path.DS.$localeCode.DS.$fileName;
-            if (!empty($filePath) && file_exists($filePath)) {
-                return $filePath;
+        
+        $localCodes = $localeCode === 'en_US'
+            ? array($localeCode)
+            : array($localeCode, 'en_US');
+
+        foreach ($localCodes as $localeCode) {
+            foreach ($paths as $path) {
+                $filePath = $path . DS . $localeCode . DS . $fileName;
+                if (!empty($filePath) && file_exists($filePath)) {
+                    return $filePath;
+                }
             }
         }
 


### PR DESCRIPTION
If required also loop the design fallback system with the locale as en_US as this fits the standard fallback system used for email templates. This prevents having to redeclare all email templates for other english locales if they are sharing with en_US.

Resolves issue #13