### PR TITLE
Fixes send of transactional mail with different store

### DIFF
--- a/source/app/code/community/Yireo/EmailOverride/Model/Email/Template.php
+++ b/source/app/code/community/Yireo/EmailOverride/Model/Email/Template.php
@@ -38,4 +38,45 @@ class Yireo_EmailOverride_Model_Email_Template extends Yireo_EmailOverride_Model
         }
         return parent::setDesignConfig($config);
     }
+
+    /**
+     * Send transactional email to recipient
+     *
+     * @param   int $templateId
+     * @param   string|array $sender sender information, can be declared as part of config path
+     * @param   string $email recipient email
+     * @param   string $name recipient name
+     * @param   array $vars variables which can be used in template
+     * @param   int|null $storeId
+     *
+     * @throws Mage_Core_Exception
+     *
+     * @return  Mage_Core_Model_Email_Template
+     */
+    public function sendTransactional($templateId, $sender, $email, $name, $vars=array(), $storeId=null)
+    {
+        /** @var Yireo_EmailOverride_Model_Translate $translator */
+        $translator = Mage::app()->getTranslator();
+        $originalTranslatorStoreId = $translator->getConfig(Mage_Core_Model_Translate::CONFIG_KEY_STORE);
+        if ($this->isDifferentStore($storeId, $originalTranslatorStoreId)) {
+            $translator->setStoreId($storeId);
+        }
+
+        parent::sendTransactional($templateId, $sender, $email, $name, $vars, $storeId);
+
+        if ($this->isDifferentStore($storeId, $originalTranslatorStoreId)) {
+            $translator->setStoreId($originalTranslatorStoreId);
+        }
+        return $this;
+    }
+
+    /**
+     * @param $storeId
+     * @param $originalTranslatorStoreId
+     * @return bool
+     */
+    public function isDifferentStore($storeId, $originalTranslatorStoreId)
+    {
+        return !is_null($storeId) && (int)$storeId !== (int)$originalTranslatorStoreId;
+    }
 }

--- a/source/app/code/community/Yireo/EmailOverride/Model/Translate.php
+++ b/source/app/code/community/Yireo/EmailOverride/Model/Translate.php
@@ -177,4 +177,14 @@ class Yireo_EmailOverride_Model_Translate extends Mage_Core_Model_Translate
     {
         return Mage::helper('emailoverride');
     }
+
+    /**
+     * @param int $storeId
+     * @return $this
+     */
+    public function setStoreId($storeId)
+    {
+        $this->_config[self::CONFIG_KEY_STORE] = $storeId;
+        return $this;
+    }
 }


### PR DESCRIPTION
If a transactional email for an order is sent from the admin store (for example via cron or via admin panel) Yireo_EmailOverride uses the base/default theme path for templates translations (instead of the theme of the store view where the order has been placed).
This PR fixes this problem.