### PR TITLE
Revert "Add compat with Fooman_EmailAttachments"

### DIFF
--- a/source/app/code/community/Yireo/EmailOverride/Model/Email/Template/Compatibility.php
+++ b/source/app/code/community/Yireo/EmailOverride/Model/Email/Template/Compatibility.php
@@ -36,10 +36,6 @@ if (Mage::helper('core')->isModuleEnabled('Aschroder_SMTPPro') && class_exists('
     class Yireo_EmailOverride_Model_Email_Template_Compatibility extends SUMOHeavy_Postmark_Model_Core_Email_Template
     {
     }
-} elseif (Mage::helper('core')->isModuleEnabled('Fooman_EmailAttachments') && class_exists('Fooman_EmailAttachments_Model_Core_Email_Template_Mailer')) {
-    class Yireo_EmailOverride_Model_Email_Template_Compatibility extends Fooman_EmailAttachments_Model_Core_Email_Template_Mailer
-    {
-    }
 } elseif (!class_exists('Yireo_EmailOverride_Model_Email_Template_Compatibility', false)) {
     class Yireo_EmailOverride_Model_Email_Template_Compatibility extends Mage_Core_Model_Email_Template
     {


### PR DESCRIPTION
This reverts commit 5d8f32c9895c3eba34599f21a1a41591756cf83b.

Reason: The original commit does not add compatibility, instead it destroys whole mailing functionality.